### PR TITLE
Add in-retrospect as a project

### DIFF
--- a/info/03_channels.md
+++ b/info/03_channels.md
@@ -7,6 +7,7 @@
 :information_source: <#684015580457467970> - *You are here.*
 :mega: <#684015688666447886> - Updates about our server.
 :ship: <#684016041445163008> - A direct bridge between the GitHub organizations and Discord.
+:park: <#898569204058427393> - A community project exploring topics of interest... and also making use of threads.
 
 > **Useful Guides**
 


### PR DESCRIPTION
The channel roster and 'main projects' will have this listed as a focus for how community members may collaborate with each other to find unique and interesting points of discussion in the games they play and the languages or packages they use.